### PR TITLE
Force correct placement of function prototypes

### DIFF
--- a/Arduino_PID_for_Espresso_v2_0/Arduino_PID_for_Espresso_v2_0.ino
+++ b/Arduino_PID_for_Espresso_v2_0/Arduino_PID_for_Espresso_v2_0.ino
@@ -83,6 +83,11 @@ long lastLeftDebounceTime = 0; // the last time the output pin was toggled
 long lastRightDebounceTime = 0; // the last time the output pin was toggled
 long debounceDelay = 300; // the debounce time
 
+//it's necessary to manually add the prototypes for the menuUsed and menuChanged functions here because the Arduino IDE's
+//automated function prototype generation system inserts them after they are referenced in the MenuBackend instantiation
+void menuUsed(MenuUseEvent used);
+void menuChanged(MenuChangeEvent changed);
+
 //Menu variables
 MenuBackend menu = MenuBackend(menuUsed,menuChanged);
 //initialize menu items


### PR DESCRIPTION
The Arduino sketch preprocessor automatically generates function prototypes for any function in a .ino file that doesn't already have a prototype. This system usually works perfectly, but in some rare cases the prototype is inserted at the wrong place in the code. That issue was ocurring in this sketch when compiled with modern versions of the Arduino development software. The solution is to manually add the problematic function prototypes in the correct place.

It's likely that the function prototypes happened to be inserted at the correct location at the time this sketch was written. In the seven years since that time, Arduino has done a major reworking of the prototype generation system. This fixed a lot of common failures of the system, but unfortunately it also created some new ones, which is what happened here.

Fixes https://github.com/CoffeeTronics/Arduino-PID-Controller-for-Espresso-V2.0/issues/2

CC: @hikerlt1951